### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - /:/rootfs:ro 
       - /var/run:/var/run:rw 
       - /sys:/sys:ro 
-      - /var/lib/docker/:/var/lib/docker:ro 
+      - /var/snap/docker/common/var-lib-docker:/var/lib/docker:ro
     depends_on: 
       - redis 
   redis: 


### PR DESCRIPTION
FYI, if you install docker w/ snap (on ubuntu 18.04), /var/lib/docker does not exists because docker is set up differently. To find the actual folder you need, run  docker info | grep "Docker Root Dir:" (mine was /var/snap/docker/common/var-lib-docker).

so changed the path to /var/snap/docker/common/var-lib-docker:/var/lib/docker:ro